### PR TITLE
Exclude master branch from the docker_test_build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ workflows:
           context:
             - docker-publish
             - aws_svc_circleci
+          filters:
+            branches:
+              ignore: master
       - docker_build_and_push:
           context:
             - docker-publish


### PR DESCRIPTION
There is no point in running the docker_test_build job when merging to master since the job ran when the changes were pushed to a feature branch.